### PR TITLE
Update git repo name for demo app

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -15,8 +15,8 @@ This guides assumes you have the following two tools installed on your developme
 ## 1. Clone the Github repo and navigate to the project directory:
 
 ```sh
-git clone git@github.com:pi-apps/platform-demo-app.git
-cd platform-demo-app
+git clone git@github.com:pi-apps/demo.git
+cd demo
 ```
 
 


### PR DESCRIPTION
Update git repo name for demo app from `platform-demo-app` to `demo` which is the actual name of the demo app. Without this change, trying to clone the repo would result in the following error 

```bash
❯ git clone git@github.com:pi-apps/platform-demo-app.git
Cloning into 'platform-demo-app'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
