### PR TITLE
Add Subscription smart contract playground

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,15 +23,15 @@
     </script>
 
     <!-- Pi Network SDK -->
-    <script src="https://sdk.minepi.com/pi-sdk.js"></script>
+    <script src="http://localhost:9000/v2-production.js"></script>
 
     <script>
-      const runSDKInSandboxMode = window.__ENV.sandbox === "true";
+      //const runSDKInSandboxMode = window.__ENV.sandbox === "true";
 
-      Pi.init({
-        version: "2.0",
-        sandbox: runSDKInSandboxMode,
-      });
+      (async () => {
+        await Pi.init({ version: "3.0",
+        smartContractOptions: { networkPassphrase: "Pi Testnet" }});
+      })();
     </script>
 
     <title>React App</title>

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -3,7 +3,6 @@ import type { CSSProperties } from "react";
 interface ProductCardProps {
   name: string;
   description: string;
-  price: number;
   pictureURL: string;
   onClickBuy: () => void;
   disabled?: boolean;
@@ -40,7 +39,7 @@ const priceSectionStyle: CSSProperties = {
   marginBottom: 8,
 };
 
-const ProductCard = ({ name, description, price, pictureURL, onClickBuy, disabled }: ProductCardProps) => {
+const ProductCard = ({ name, description, pictureURL, onClickBuy, disabled }: ProductCardProps) => {
   return (
     <div style={containerStyle}>
       <div style={contentRowStyle}>
@@ -55,9 +54,8 @@ const ProductCard = ({ name, description, price, pictureURL, onClickBuy, disable
       </div>
 
       <div style={priceSectionStyle}>
-        <strong>{price} Test-π</strong> <br />
         <button onClick={onClickBuy} disabled={disabled}>
-          Order
+          subscribe
         </button>
       </div>
     </div>

--- a/frontend/src/components/SubscriptionPanel.tsx
+++ b/frontend/src/components/SubscriptionPanel.tsx
@@ -1,0 +1,300 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+
+const DEFAULT_MERCHANT = "GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2";
+const DEFAULT_CUSTOMER = "GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G";
+
+type RunState = {
+  action: string;
+  status: "loading" | "ok" | "error";
+  data?: unknown;
+  error?: string;
+};
+
+const containerStyle: CSSProperties = {
+  margin: 16,
+  display: "flex",
+  flexDirection: "column",
+  gap: 16,
+};
+
+const sharedBoxStyle: CSSProperties = {
+  border: "1px solid #999",
+  borderRadius: 8,
+  padding: 16,
+  background: "#f7f7f7",
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+};
+
+const cardStyle: CSSProperties = {
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  padding: 16,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+};
+
+const labelStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: "#444",
+  marginBottom: 2,
+};
+
+const inputStyle: CSSProperties = {
+  width: "100%",
+  padding: "6px 8px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  fontSize: 13,
+  fontFamily: "monospace",
+};
+
+const buttonStyle: CSSProperties = {
+  alignSelf: "flex-start",
+  padding: "8px 16px",
+  border: "none",
+  borderRadius: 6,
+  background: "#6b3fa0",
+  color: "white",
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const descStyle: CSSProperties = {
+  fontSize: 13,
+  color: "#555",
+  margin: 0,
+};
+
+const outputStyle: CSSProperties = {
+  border: "1px solid #ccc",
+  borderRadius: 8,
+  padding: 16,
+  background: "#1e1e1e",
+  color: "#e0e0e0",
+  fontFamily: "monospace",
+  fontSize: 12,
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-all",
+  maxHeight: 320,
+  overflow: "auto",
+};
+
+const fieldsRowStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 12,
+};
+
+const Field = ({
+  label,
+  value,
+  onChange,
+  placeholder,
+  width = 160,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  width?: number | string;
+}) => (
+  <label style={{ display: "flex", flexDirection: "column", flex: `1 1 ${typeof width === "number" ? `${width}px` : width}`, minWidth: 120 }}>
+    <span style={labelStyle}>{label}</span>
+    <input style={inputStyle} value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+  </label>
+);
+
+const ActionCard = ({
+  title,
+  signature,
+  description,
+  children,
+  onRun,
+  disabled,
+}: {
+  title: string;
+  signature: string;
+  description: string;
+  children?: ReactNode;
+  onRun: () => void;
+  disabled?: boolean;
+}) => (
+  <div style={cardStyle}>
+    <h3 style={{ margin: 0 }}>{title}</h3>
+    <code style={{ fontSize: 12, color: "#6b3fa0", wordBreak: "break-all" }}>{signature}</code>
+    <p style={descStyle}>{description}</p>
+    {children && <div style={fieldsRowStyle}>{children}</div>}
+    <button style={{ ...buttonStyle, opacity: disabled ? 0.6 : 1 }} onClick={onRun} disabled={disabled}>
+      Run
+    </button>
+  </div>
+);
+
+const SubscriptionPanel = () => {
+  // Shared, reused across methods
+  const [merchant, setMerchant] = useState(DEFAULT_MERCHANT);
+  const [customer, setCustomer] = useState(DEFAULT_CUSTOMER);
+  const [sharedId, setSharedId] = useState("79");
+
+  // registerService params
+  const [serviceName, setServiceName] = useState("new-test");
+  const [serviceDescription, setServiceDescription] = useState("200000000");
+  const [servicePrice, setServicePrice] = useState("120");
+  const [serviceDuration, setServiceDuration] = useState("0");
+  const [serviceInterval, setServiceInterval] = useState("12");
+
+  // process params
+  const [offset, setOffset] = useState("0");
+  const [limit, setLimit] = useState("1");
+
+  // subscribe params
+  const [isAutoRenew, setIsAutoRenew] = useState(true);
+  const [subscribeParam, setSubscribeParam] = useState("10");
+
+  const [result, setResult] = useState<RunState | null>(null);
+
+  const run = async (action: string, fn: () => Promise<unknown>) => {
+    const sub = window.Pi?.SmartContract?.Subscription;
+    if (!sub) {
+      setResult({ action, status: "error", error: "window.Pi.SmartContract.Subscription is not available. Open this app inside the Pi Browser." });
+      return;
+    }
+    setResult({ action, status: "loading" });
+    try {
+      const data = await fn();
+      console.log(`[${action}] result:`, data);
+      setResult({ action, status: "ok", data });
+    } catch (err) {
+      console.error(`[${action}] error:`, err);
+      setResult({ action, status: "error", error: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  const sub = () => window.Pi.SmartContract.Subscription;
+
+  return (
+    <div style={containerStyle}>
+      <h2 style={{ margin: 0 }}>Subscription Smart Contract Playground</h2>
+
+      <div style={sharedBoxStyle}>
+        <h3 style={{ margin: 0 }}>Shared fields (reused across methods)</h3>
+        <div style={fieldsRowStyle}>
+          <Field label="Merchant address" value={merchant} onChange={setMerchant} width="100%" />
+          <Field label="Customer address" value={customer} onChange={setCustomer} width="100%" />
+          <Field
+            label="Reusable ID (service / subscription id)"
+            value={sharedId}
+            onChange={setSharedId}
+            placeholder="e.g. 79"
+            width={200}
+          />
+        </div>
+      </div>
+
+      <ActionCard
+        title="Register Service"
+        signature="registerService(merchant, name, description, price, duration, interval)"
+        description="Merchant registers a new subscription service. Uses the shared Merchant address."
+        onRun={() =>
+          run("registerService", () =>
+            sub().registerService(merchant, serviceName, serviceDescription, servicePrice, serviceDuration, serviceInterval)
+          )
+        }
+      >
+        <Field label="Service name" value={serviceName} onChange={setServiceName} />
+        <Field label="Description" value={serviceDescription} onChange={setServiceDescription} />
+        <Field label="Price" value={servicePrice} onChange={setServicePrice} />
+        <Field label="Duration" value={serviceDuration} onChange={setServiceDuration} />
+        <Field label="Interval" value={serviceInterval} onChange={setServiceInterval} />
+      </ActionCard>
+
+      <ActionCard
+        title="Get Merchant Services"
+        signature="getMerchantServices(merchant)"
+        description="Lists all services registered by the shared Merchant address."
+        onRun={() => run("getMerchantServices", () => sub().getMerchantServices(merchant))}
+      />
+
+      <ActionCard
+        title="Get Service"
+        signature="getService(merchant, serviceId)"
+        description="Fetches a single service by ID. Uses shared Merchant address and the shared reusable ID."
+        onRun={() => run("getService", () => sub().getService(merchant, sharedId))}
+      />
+
+      <ActionCard
+        title="Process"
+        signature="process(merchant, serviceId, offset, limit)"
+        description="Processes due charges for a service. Uses shared Merchant address and the shared reusable ID as the service id."
+        onRun={() => run("process", () => sub().process(merchant, sharedId, Number(offset), Number(limit)))}
+      >
+        <Field label="Offset" value={offset} onChange={setOffset} width={100} />
+        <Field label="Limit" value={limit} onChange={setLimit} width={100} />
+      </ActionCard>
+
+      <ActionCard
+        title="Subscribe"
+        signature="subscribe(customer, serviceId, isAutoRenew, param)"
+        description="Customer subscribes to a service. Uses shared Customer address and the shared reusable ID as the service/product id."
+        onRun={() => run("subscribe", () => sub().subscribe(customer, sharedId, isAutoRenew, subscribeParam))}
+      >
+        <label style={{ display: "flex", flexDirection: "column", flex: "1 1 140px", minWidth: 120 }}>
+          <span style={labelStyle}>Auto renew</span>
+          <span style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 0" }}>
+            <input type="checkbox" checked={isAutoRenew} onChange={(e) => setIsAutoRenew(e.target.checked)} />
+            <span style={{ fontSize: 13 }}>{isAutoRenew ? "true" : "false"}</span>
+          </span>
+        </label>
+        <Field label="Param" value={subscribeParam} onChange={setSubscribeParam} width={120} />
+      </ActionCard>
+
+      <ActionCard
+        title="Get Subscription"
+        signature="getSubscription(customer, subscriptionId)"
+        description="Fetches a subscription by ID. Uses shared Customer address and the shared reusable ID as the subscription id."
+        onRun={() => run("getSubscription", () => sub().getSubscription(customer, sharedId))}
+      />
+
+      <ActionCard
+        title="Get Subscription Reservation"
+        signature="getSubscriptionReservation(customer, subscriptionId)"
+        description="Fetches the reservation for a subscription. Uses shared Customer address and the shared reusable ID."
+        onRun={() => run("getSubscriptionReservation", () => sub().getSubscriptionReservation(customer, sharedId))}
+      />
+
+      <ActionCard
+        title="Get Subscriber Subscriptions"
+        signature="getSubscriberSubscriptions(customer)"
+        description="Lists all subscriptions belonging to the shared Customer address."
+        onRun={() => run("getSubscriberSubscriptions", () => sub().getSubscriberSubscriptions(customer))}
+      />
+
+      {result && (
+        <div>
+          <h3 style={{ marginBottom: 8 }}>
+            Output — <code>{result.action}</code>{" "}
+            <span
+              style={{
+                fontSize: 12,
+                color: result.status === "error" ? "#c0392b" : result.status === "ok" ? "#27ae60" : "#888",
+              }}
+            >
+              ({result.status})
+            </span>
+          </h3>
+          <div style={outputStyle}>
+            {result.status === "loading" && "Running..."}
+            {result.status === "error" && result.error}
+            {result.status === "ok" && JSON.stringify(result.data, (_k, v) => (typeof v === "bigint" ? v.toString() : v), 2)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SubscriptionPanel;

--- a/frontend/src/hooks/usePayments.ts
+++ b/frontend/src/hooks/usePayments.ts
@@ -11,7 +11,7 @@ type UsePaymentsArgs = {
   onRequireAuth: () => void;
 };
 
-export const usePayments = ({ isAuthenticated, onRequireAuth }: UsePaymentsArgs) => {
+export const usePayments = ({ isAuthenticated: _isAuthenticated, onRequireAuth: _onRequireAuth }: UsePaymentsArgs) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const onReadyForServerApproval = useCallback(async (paymentId: string) => {
@@ -43,35 +43,74 @@ export const usePayments = ({ isAuthenticated, onRequireAuth }: UsePaymentsArgs)
     setIsLoading(false);
   }, []);
 
-  const orderProduct = useCallback(
-    async (memo: string, amount: number, metadata: PaymentMetadata) => {
-      if (!isAuthenticated) {
-        onRequireAuth();
-        return;
-      }
+  //below code actually subscribes to the service
+  const orderProduct1 = useCallback(async () => {
+    //const res = await window.Pi.SmartContract.Subscription.registerService("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "new-test", "200000000", "120", "0", "12");
+    //const res = await window.Pi.SmartContract.Subscription.getMerchantServices("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2");
+    //const res = await window.Pi.SmartContract.Subscription.process("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "241", 0, 1);
+    //const res = await window.Pi.SmartContract.Subscription.subscribe("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "249", true, "10");
+    //const res = await window.Pi.SmartContract.Subscription.getSubscriberSubscriptions("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G");
+    //const res = await window.Pi.SmartContract.Subscription.getService("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "69");
+    ///const res = await window.Pi.SmartContract.Subscription.extendSubscription("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G","57");
+    //const res = await window.Pi.SmartContract.pollTransaction("9db4228497076d92603f617a896bc09466c911b919d3a8e060b00de450cadf35", 10);
+    const res = await window.Pi.SmartContract.Subscription.process("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "249", 0, 1);
+    //const res = (await window.Pi.SmartContract.Subscription.process("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "248", 0, 1)) as { hash: string };
+    //const finalRes = await window.Pi.SmartContract.pollTransaction(res.hash);
+    //const res = await window.Pi.SmartContract.Subscription.getSubscription("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "67");
 
-      setIsLoading(true);
-      try {
-        await window.Pi.createPayment(
-          { amount, memo, metadata },
-          {
-            onReadyForServerApproval,
-            onReadyForServerCompletion,
-            onCancel,
-            onError,
-          }
-        );
-      } catch (err) {
-        console.error("Error creating payment:", err);
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [isAuthenticated, onRequireAuth, onReadyForServerApproval, onReadyForServerCompletion, onCancel, onError]
-  );
+    //const res = await window.Pi.SmartContract.Subscription.getSubscriptionReservation("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "63");
+
+    console.log('First Res: ', res);
+    //console.log('First Final Result: ', finalRes);
+  }, []);
+
+  const orderProduct2 = useCallback(async () => {
+    //const res1 = await window.Pi.SmartContract.Subscription.getSubscriberSubscriptions("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G");
+    //const res = await window.Pi.SmartContract.Subscription.getSubscription("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "61");
+    //const res = await window.Pi.SmartContract.Subscription.registerService("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "sub-app-no-free-trial", "5000000", "300", "0", "12");
+    //const res = await window.Pi.SmartContract.Subscription.getMerchantServices("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2");
+    //const res = await window.Pi.SmartContract.Subscription.subscribe("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "206", true, "1");
+    //const res = await window.Pi.SmartContract.Subscription.process("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "240", 0, 1);
+    //const res = await window.Pi.SmartContract.Subscription.extendSubscription("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G","63", "4");
+    //const res = await window.Pi.SmartContract.Subscription.getService("GCYIUNNZTIXTLYDV3K6DCVOOJYKFOSAEQLGH3BD7D6EQ2RCUPAARYVO2", "209");
+    const res1 = await window.Pi.SmartContract.Subscription.getSubscription("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "79");
+
+    const res2 = await window.Pi.SmartContract.Subscription.getSubscriptionReservation("GAGOPQNJJEITO7FQC7VXICCJDLSJ5BDMABS4PPZ6JG2MJS6PQSIWIT6G", "79");
+
+      console.log('Second res1: ', res1);
+      console.log('Second res2: ', res2);
+    }, []);
+
+  // const orderProduct = useCallback(
+  //   async (memo: string, amount: number, metadata: PaymentMetadata) => {
+  //     if (!isAuthenticated) {
+  //       onRequireAuth();
+  //       return;
+  //     }
+
+  //     setIsLoading(true);
+  //     try {
+  //       await window.Pi.createPayment(
+  //         { amount, memo, metadata },
+  //         {
+  //           onReadyForServerApproval,
+  //           onReadyForServerCompletion,
+  //           onCancel,
+  //           onError,
+  //         }
+  //       );
+  //     } catch (err) {
+  //       console.error("Error creating payment:", err);
+  //     } finally {
+  //       setIsLoading(false);
+  //     }
+  //   },
+  //   [isAuthenticated, onRequireAuth, onReadyForServerApproval, onReadyForServerCompletion, onCancel, onError]
+  // );
 
   return {
-    orderProduct,
+    orderProduct1,
+    orderProduct2,
     isLoading,
   };
 };

--- a/frontend/src/pages/Shop.tsx
+++ b/frontend/src/pages/Shop.tsx
@@ -1,27 +1,19 @@
 import Header from "../components/Header";
-import ProductCard from "../components/ProductCard";
 import SignIn from "../components/SignIn";
+import SubscriptionPanel from "../components/SubscriptionPanel";
 
 import { useAuth } from "../hooks/useAuth";
-import { usePayments } from "../hooks/usePayments";
 import { axiosClient } from "../lib/axiosClient.ts";
 
 const Shop = () => {
   const {
     user,
-    isAuthenticated,
     showSignIn,
     signIn,
     signOut,
     closeSignIn,
-    requireAuth,
     isLoading: isAuthLoading,
   } = useAuth();
-
-  const { orderProduct, isLoading } = usePayments({
-    isAuthenticated,
-    onRequireAuth: requireAuth,
-  });
 
   const onSendTestNotification = () => {
     const notification = {
@@ -43,27 +35,7 @@ const Shop = () => {
         isLoading={isAuthLoading}
       />
 
-      <ProductCard
-        name="Apple Pie"
-        description="You know what this is. Pie. Apples. Apple pie."
-        price={0.1}
-        pictureURL="https://upload.wikimedia.org/wikipedia/commons/4/4b/Apple_pie.jpg"
-        onClickBuy={() => orderProduct("Order Apple Pie", 0.1, { productId: "apple_pie_1" })}
-        disabled={isLoading}
-      />
-
-      <ProductCard
-        name="Lemon Meringue Pie"
-        description="Order at your own risk."
-        price={0.2}
-        pictureURL="https://live.staticflickr.com/1156/5134246283_f2686ff8a8_b.jpg"
-        onClickBuy={() =>
-          orderProduct("Order Lemon Meringue Pie", 0.2, {
-            productId: "lemon_pie_1",
-          })
-        }
-        disabled={isLoading}
-      />
+      <SubscriptionPanel />
 
       {showSignIn && <SignIn onSignIn={signIn} onModalClose={closeSignIn} disabled={isAuthLoading} />}
     </>

--- a/frontend/src/types/window.d.ts
+++ b/frontend/src/types/window.d.ts
@@ -22,6 +22,22 @@ declare global {
           onError: (error: Error, payment?: PaymentDTO) => void;
         }
       ): Promise<unknown>;
+
+      SmartContract: {
+        Subscription: {
+          getSubscriberSubscriptions(subscriberId: string): Promise<unknown>;
+          subscribe(subscriberId: string, productId: string, isAutoRenew: boolean, someParam: string): Promise<unknown>;
+          registerService(subscriberId: string, serviceName: string, serviceDescription: string, servicePrice: string, serviceDuration: string, serviceInterval: string): Promise<unknown>;
+          getMerchantServices(merchantId: string): Promise<unknown>;
+          getService(merchantId: string, serviceId: string): Promise<unknown>;
+          process(merchant: string, serviceId: string | bigint, offset: string | number | bigint, limit: string | number | bigint, options?: ExecuteOptions): Promise<unknown>;
+          extendSubscription(subscriberId: string, subscriptionId: string | bigint, newDuration: string | number | bigint, options?: ExecuteOptions): Promise<unknown>;
+          getSubscription(subscriberId: string, subscriptionId: string | bigint): Promise<unknown>;
+          pollTransaction(txHash: string, attempts?: number): Promise<unknown>;
+          getSubscriptionReservation(subscriberId: string, subscriptionId: string | bigint): Promise<unknown>;
+        };
+          pollTransaction(txHash: string, attempts?: number): Promise<unknown>;
+      };
     };
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -165,22 +165,6 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
-"@emotion/cache@^11.14.0":
-  version "11.14.0"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.14.0.tgz#ee44b26986eeb93c8be82bb92f1f7a9b21b2ed76"
-  integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
-  dependencies:
-    "@emotion/memoize" "^0.9.0"
-    "@emotion/sheet" "^1.4.0"
-    "@emotion/utils" "^1.4.2"
-    "@emotion/weak-memoize" "^0.4.0"
-    stylis "4.2.0"
-
-"@emotion/hash@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
-  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
-
 "@emotion/is-prop-valid@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz#e9ad47adff0b5c94c72db3669ce46de33edf28c0"
@@ -193,36 +177,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/serialize@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.3.tgz#d291531005f17d704d0463a032fe679f376509e8"
-  integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
-  dependencies:
-    "@emotion/hash" "^0.9.2"
-    "@emotion/memoize" "^0.9.0"
-    "@emotion/unitless" "^0.10.0"
-    "@emotion/utils" "^1.4.2"
-    csstype "^3.0.2"
-
-"@emotion/sheet@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
-  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
-
-"@emotion/unitless@0.10.0", "@emotion/unitless@^0.10.0":
+"@emotion/unitless@0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
   integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
-
-"@emotion/utils@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
-  integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
-
-"@emotion/weak-memoize@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
-  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@esbuild/aix-ppc64@0.27.4":
   version "0.27.4"
@@ -529,16 +487,15 @@
     hoist-non-react-statics "^3.3.2"
     prop-types "^15.8.1"
 
-"@mui/styled-engine@^7.3.9":
-  version "7.3.9"
-  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-7.3.9.tgz#e425ca7b5cb559bde01b8fa4a7a842e9b5916f53"
-  integrity sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==
+"@mui/styled-engine@^7.3.9", "@mui/styled-engine@npm:@mui/styled-engine-sc@^7.3.9":
+  version "7.3.10"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine-sc/-/styled-engine-sc-7.3.10.tgz#fb2aa91282bd73b479761195203adfa3752eb06f"
+  integrity sha512-h0MbZwKFff8Y6gSVnQfSnQOUd3j0d6wqHhpIL0OmE2LF48iM+CMEhhYBHEGsaDEPigv0USTE041To5qZsXKyKQ==
   dependencies:
     "@babel/runtime" "^7.28.6"
-    "@emotion/cache" "^11.14.0"
-    "@emotion/serialize" "^1.3.3"
-    "@emotion/sheet" "^1.4.0"
+    "@types/hoist-non-react-statics" "^3.3.7"
     csstype "^3.2.3"
+    hoist-non-react-statics "^3.3.2"
     prop-types "^15.8.1"
 
 "@mui/system@^7.3.9":
@@ -1935,11 +1892,6 @@ styled-components@^6.3.12:
     shallowequal "1.1.0"
     stylis "4.3.6"
     tslib "2.8.1"
-
-stylis@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
-  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 stylis@4.3.6:
   version "4.3.6"


### PR DESCRIPTION
## Summary
- Replaces the Order Apple/Lemon Pie payment demo on the Shop page with a `SubscriptionPanel` UI for exercising `window.Pi.SmartContract.Subscription` methods (registerService, subscribe, process, getSubscription, getSubscriptionReservation, getSubscriberSubscriptions, etc.)
- Adds corresponding `SmartContract.Subscription` type declarations to `window.d.ts`
- Note: `frontend/index.html` currently points the Pi SDK to `http://localhost:9000/v2-production.js` (SDK v3.0) instead of the CDN — a local dev override left in intentionally per author's request, should be reviewed before merge
- `usePayments.ts` retains commented-out debug experiments used while building the panel — also left as-is per author's request

## Test plan
- [ ] Restore SDK src to CDN (or confirm intentional) before merging
- [ ] Open Shop page inside Pi Browser and verify SubscriptionPanel renders and each action calls through to `window.Pi.SmartContract.Subscription`
- [ ] Clean up leftover debug code in `usePayments.ts` if not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)